### PR TITLE
fix typo in flow-control-statements

### DIFF
--- a/src/pages/flow-control-statements/README.md
+++ b/src/pages/flow-control-statements/README.md
@@ -79,7 +79,7 @@ switch (favorite) {
         break;
     case "red":
         console.log("red");
-    case "pruple":
+    case "purple":
         console.log("(and) purple");
     default:
         console.log("white");
@@ -95,7 +95,7 @@ case "yellow":
 case "red":
 	fmt.Println("red")
 	fallthrough
-case "pruple":
+case "purple":
 	fmt.Println("(and) purple")
 default:
 	fmt.Println("white")


### PR DESCRIPTION
Fixes a cosmetic typo / spelling mistake in the flow-control-statements section